### PR TITLE
Fix build error with "/std:c++20"

### DIFF
--- a/Source/SpotlightSearch/Private/Extensions/ReflectionFunctionsExtension.cpp
+++ b/Source/SpotlightSearch/Private/Extensions/ReflectionFunctionsExtension.cpp
@@ -21,7 +21,7 @@ TArray<TSharedPtr<FQuickCommandEntry>> UReflectionFunctionsExtension::GetCommand
 				FunctionEntry->Tooltip = FText::FromString(Function->GetDesc());
 				FunctionEntry->Icon = FSlateIcon(FAppStyle::GetAppStyleSetName(), "Kismet.AllClasses.FunctionIcon");
 				FunctionEntry->ExecuteCallback = FSimpleDelegate::CreateLambda(
-					[=]()
+					[=, this]()
 					{
 						ProcessEvent(Function, nullptr);
 					}


### PR DESCRIPTION
Explicit capture of this using [=] is deprecated in c++20.

> D:\Build\5.3\QuickActions\HostProject\Plugins\QuickActions\Source\SpotlightSearch\Private\Extensions\ReflectionFunctionsExtension.cpp(26): error C4855: Die implizite Erfassung von "this" über "[=]" ist in "/std:c++20" veraltet.