### PR TITLE
 error C3791: 'this' cannot be explicitly captured when the default c…

### DIFF
--- a/Source/SpotlightSearch/Private/Extensions/ReflectionFunctionsExtension.cpp
+++ b/Source/SpotlightSearch/Private/Extensions/ReflectionFunctionsExtension.cpp
@@ -21,7 +21,7 @@ TArray<TSharedPtr<FQuickCommandEntry>> UReflectionFunctionsExtension::GetCommand
 				FunctionEntry->Tooltip = FText::FromString(Function->GetDesc());
 				FunctionEntry->Icon = FSlateIcon(FAppStyle::GetAppStyleSetName(), "Kismet.AllClasses.FunctionIcon");
 				FunctionEntry->ExecuteCallback = FSimpleDelegate::CreateLambda(
-					[=, this]()
+					[=]()
 					{
 						ProcessEvent(Function, nullptr);
 					}


### PR DESCRIPTION
…apture mode is by copy (=)

\SpotlightSearch\Private\Extensions\ReflectionFunctionsExtension.cpp(24): error C3791: 'this' cannot be explicitly captured when the default capture mode is by copy (=)